### PR TITLE
Optional delay for self play

### DIFF
--- a/self_play.py
+++ b/self_play.py
@@ -49,7 +49,7 @@ if torch.cuda.is_available():
 logger = logging.getLogger(__name__)
 
 
-def self_play(model, num_games=100, device=None):
+def self_play(model, num_games=100, device=None, sleep_time=0.0):
     print("✅ self_play() function has started executing", flush=True)
     data = []
     model.eval()
@@ -103,7 +103,8 @@ def self_play(model, num_games=100, device=None):
             gs.makeMove(move)
             move_count += 1
 
-            time.sleep(0.01)
+            if sleep_time:
+                time.sleep(sleep_time)
 
         if move_count >= MAX_MOVES:
             result_reason = "Max move limit reached"
@@ -167,8 +168,8 @@ def piece_value(piece):
     return values.get(piece.upper(), 0)
 
 
-def generate_self_play_data(model, num_games=50, device=None):
-    return self_play(model, num_games, device)
+def generate_self_play_data(model, num_games=50, device=None, sleep_time=0.0):
+    return self_play(model, num_games, device, sleep_time)
 
 if __name__ == "__main__":
     model = ChessNet()


### PR DESCRIPTION
## Summary
- allow configurable sleep in self-play loop

## Testing
- `PYTHONPATH=. pytest -q`
- `pip install torch` *(fails: blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fcf95481c83228581797e25d699eb