### PR TITLE
Use dataset directly in training

### DIFF
--- a/learn.py
+++ b/learn.py
@@ -65,13 +65,12 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # === Model, Dataset, Optimizer ===
 model = ChessNet().to(device)
 dataset = ChessPGNDataset(games_path, max_samples=100000)
-training_data = [dataset[i] for i in range(len(dataset))]
 optimizer = optim.Adam(model.parameters(), lr=1e-3)
 
 # === Start Training ===
 train_model(
     model=model,
-    data=training_data,
+    data=dataset,
     optimizer=optimizer,
     start_epoch=0,
     epochs=10000,
@@ -583,13 +582,12 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = ChessNet().to(device)
     dataset = ChessPGNDataset(games_path, max_samples=100000)
-    training_data = [dataset[i] for i in range(len(dataset))]
     optimizer = optim.Adam(model.parameters(), lr=1e-3)
 
     # === Train the model ===
     train_model(
         model=model,
-        data=training_data,
+        data=dataset,
         optimizer=optimizer,
         start_epoch=0,
         epochs=10000,

--- a/train.py
+++ b/train.py
@@ -143,11 +143,16 @@ if len(dataset) == 0:
     print("✅ Telegram message sent.")
     sys.exit(1)
 
-print("✅ DataLoader initialized")
+print("✅ Dataset ready")
                 
 
 def train_model(model, data, optimizer, start_epoch=0, epochs=2, batch_size=2048, device='cpu', pin_memory=False):
-    dataloader = DataLoader(data, batch_size=batch_size, shuffle=True, pin_memory=pin_memory)
+    if isinstance(data, DataLoader):
+        dataloader = data
+        dataset = dataloader.dataset
+    else:
+        dataloader = DataLoader(data, batch_size=batch_size, shuffle=True, pin_memory=pin_memory)
+        dataset = data
     writer = SummaryWriter(log_dir=os.path.join(BASE_DIR, "runs", run_name))
     print(f"Logging to: runs/{run_name}")
     model.train()
@@ -249,9 +254,12 @@ def train_model(model, data, optimizer, start_epoch=0, epochs=2, batch_size=2048
         print("♟️ Generating self-play games...")
         num_selfplay_games = int(os.getenv("NUM_SELFPLAY_GAMES", 50))
         new_selfplay_data = generate_self_play_data(model=model, num_games=num_selfplay_games)
-        if new_selfplay_data:
-            data.extend(new_selfplay_data)
+        if new_selfplay_data and hasattr(dataset, "extend"):
+            dataset.extend(new_selfplay_data)
+            dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True, pin_memory=pin_memory)
             print(f"✅ {len(new_selfplay_data)} self-play games added to training set.")
+        elif new_selfplay_data:
+            print("⚠️ Dataset does not support extension; self-play data ignored.")
         else:
             print("⚠️ No self-play games generated.")
 
@@ -368,7 +376,7 @@ def capture_and_train():
         with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
             result = train_model(
                 model=model,
-                data=training_dataset,
+                data=dataset,
                 optimizer=optimizer,
                 start_epoch=start_epoch,
                 epochs=100,


### PR DESCRIPTION
## Summary
- avoid converting `ChessPGNDataset` into an intermediate list
- handle dataset or DataLoader inputs in `train_model`
- update `learn.py` and training script to pass the dataset directly

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcf6d17ac8322a871b0b4be58d6ab