### PR TITLE
Ensure tests can import project modules

### DIFF
--- a/tests/test_castling.py
+++ b/tests/test_castling.py
@@ -1,4 +1,8 @@
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from chessEngine import GameState, Move
 
 class TestCastling(unittest.TestCase):

--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -1,5 +1,8 @@
 import unittest
+import os
+import sys
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from chessEngine import GameState, Move
 
 

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,4 +1,8 @@
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from chessEngine import GameState, Move
 
 class TestPromotion(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add path adjustments in tests to allow importing project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd18dd1648322b58f02a4d2671892