### PR TITLE
Remove debug prints from forward

### DIFF
--- a/model.py
+++ b/model.py
@@ -5,8 +5,9 @@ import torch.nn as nn
 torch.backends.cudnn.benchmark = True
 
 class ChessNet(nn.Module):
-    def __init__(self):
+    def __init__(self, verbose: bool = False):
         super(ChessNet, self).__init__()
+        self.verbose = verbose
         self.conv1 = nn.Conv2d(12, 256, kernel_size=3, padding=1)
         self.bn1 = nn.BatchNorm2d(256)
 
@@ -34,7 +35,8 @@ class ChessNet(nn.Module):
 
     def forward(self, x):
         x = x.to(next(self.parameters()).device)
-        print("📥 Forward input shape:", x.shape)
+        if self.verbose:
+            print("📥 Forward input shape:", x.shape)
         # Removed autocast to ensure consistent dtype across input and model parameters
         x = torch.relu(self.bn1(self.conv1(x)))
         x = torch.relu(self.bn2(self.conv2(x)))
@@ -48,12 +50,14 @@ class ChessNet(nn.Module):
         policy = torch.relu(self.policy_bn(self.policy_conv(x)))
         policy = torch.flatten(policy, 1)
         policy = self.policy_fc(policy)
-        print("📤 Policy output shape:", policy.shape)
+        if self.verbose:
+            print("📤 Policy output shape:", policy.shape)
 
         value = torch.relu(self.value_bn(self.value_conv(x)))
         value = value.view(value.size(0), -1)
         value = torch.relu(self.value_fc1(value))
         value = torch.tanh(self.value_fc2(value))
-        print("📤 Value output shape:", value.shape)
+        if self.verbose:
+            print("📤 Value output shape:", value.shape)
 
         return policy.to(x.device), value.to(x.device)


### PR DESCRIPTION
## Summary
- add a `verbose` flag to `ChessNet`
- gate `forward` debug output behind the flag

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcf8fb98c8322b671167beef74998