### PR TITLE
Add ENABLE_TELEGRAM flag

### DIFF
--- a/parser_pgn.py
+++ b/parser_pgn.py
@@ -8,6 +8,10 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 def send_telegram_message(message):
+    if str(os.getenv("ENABLE_TELEGRAM", "true")).lower() in ("false", "0", "no"):
+        logger.info("📵 Telegram disabled via ENABLE_TELEGRAM. Skipping message.")
+        return
+
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if not token or not chat_id:
@@ -31,6 +35,9 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
 
 def notify_bot(message):
+    if str(os.getenv("ENABLE_TELEGRAM", "true")).lower() in ("false", "0", "no"):
+        logger.info("📵 Telegram disabled via ENABLE_TELEGRAM. Skipping message.")
+        return
     try:
         requests.post(
             f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage",

--- a/split_human_data.py
+++ b/split_human_data.py
@@ -14,6 +14,10 @@ output_dir = os.path.join(BASE_DIR, "data/human_batches")
 lines_per_file = 100000  # 100,000 lines per file
 
 def notify_bot(message):
+    if str(os.getenv("ENABLE_TELEGRAM", "true")).lower() in ("false", "0", "no"):
+        print("📵 Telegram disabled via ENABLE_TELEGRAM. Skipping message.")
+        return
+
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if not token or not chat_id:

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -6,6 +6,11 @@ def send_telegram_message(message, parse_mode="HTML"):
     Sends a message to a Telegram bot using credentials stored in environment variables.
     Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID to be set in .env or system environment.
     """
+    enable_flag = str(os.getenv("ENABLE_TELEGRAM", "true")).lower()
+    if enable_flag in ("false", "0", "no"):
+        print("📵 Telegram disabled via ENABLE_TELEGRAM. Skipping message.")
+        return
+
     if not message or not str(message).strip():
         print("⚠️ Skipping Telegram message: empty content")
         return

--- a/train.py
+++ b/train.py
@@ -339,6 +339,9 @@ telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
 telegram_chat_id = os.getenv("TELEGRAM_CHAT_ID")
 
 def send_telegram_message(message):
+    if str(os.getenv("ENABLE_TELEGRAM", "true")).lower() in ("false", "0", "no"):
+        print("📵 Telegram disabled via ENABLE_TELEGRAM. Skipping message.")
+        return
     global telegram
     if telegram_token and telegram_chat_id:
         try:


### PR DESCRIPTION
## Summary
- add `ENABLE_TELEGRAM` check in `telegram_utils.send_telegram_message`
- respect the flag in `parser_pgn.notify_bot` and `split_human_data.notify_bot`
- add flag handling to `train.send_telegram_message`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505b2c61d08322b176400d7cba432d